### PR TITLE
Allowed dice rolls without roll times (eg: d6)

### DIFF
--- a/spec/parser/dice-parser.parseDice.spec.ts
+++ b/spec/parser/dice-parser.parseDice.spec.ts
@@ -6,6 +6,39 @@ import { MockLexer } from '../helpers';
 
 describe('DiceParser', () => {
   describe('parseDice', () => {
+    it('can correctly parse a simple dice roll without roll times.', () => {
+      const lexer = new MockLexer([
+          new Token(TokenType.Identifier, 0, 'd'),
+          new Token(TokenType.Number, 1, '6')
+      ]);
+      const parser = new Parser.DiceParser(lexer);
+      const result = new ParseResult();
+      const dice = parser.parseDice(result);
+      expect(result.errors.length).toBe(0);
+
+      expect(dice.type).toBe(NodeType.Dice);
+      expect(dice.getChildCount()).toBe(2);
+      expect(dice.getChild(0).type).toBe(NodeType.Number);
+      expect(dice.getChild(0).getAttribute('value')).toBe(1);
+      expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
+      expect(dice.getChild(1).getAttribute('value')).toBe(6);
+    });
+    it('can correctly parse a simple fate dice roll without roll times.', () => {
+      const lexer = new MockLexer([
+          new Token(TokenType.Identifier, 0, 'dF'),
+      ]);
+      const parser = new Parser.DiceParser(lexer);
+      const result = new ParseResult();
+      const dice = parser.parseDice(result);
+      expect(result.errors.length).toBe(0);
+
+      expect(dice.type).toBe(NodeType.Dice);
+      expect(dice.getChildCount()).toBe(2);
+      expect(dice.getChild(0).type).toBe(NodeType.Number);
+      expect(dice.getChild(0).getAttribute('value')).toBe(1);
+      expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
+      expect(dice.getChild(1).getAttribute('value')).toBe('fate');
+    });
     it('can correctly parse a simple dice roll with pre-parsed number.', () => {
       const lexer = new MockLexer([
         new Token(TokenType.Number, 0, '10'),

--- a/spec/parser/dice-parser.parseDiceRoll.spec.ts
+++ b/spec/parser/dice-parser.parseDiceRoll.spec.ts
@@ -40,6 +40,22 @@ describe('DiceParser', () => {
       expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
       expect(dice.getChild(1).getAttribute('value')).toBe(6);
     });
+    it('can correctly parse a simple dice roll without roll times.', () => {
+      const lexer = new MockLexer([
+          new Token(TokenType.Identifier, 0, 'd'),
+          new Token(TokenType.Number, 1, '6')
+      ]);
+      const parser = new Parser.DiceParser(lexer);
+      const result = new Parser.ParseResult();
+      const dice = parser.parseDiceRoll(result);
+      expect(result.errors.length).toBe(0);
+      expect(dice.type).toBe(NodeType.Dice);
+      expect(dice.getChildCount()).toBe(2);
+      expect(dice.getChild(0).type).toBe(NodeType.Number);
+      expect(dice.getChild(0).getAttribute('value')).toBe(1);
+      expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
+      expect(dice.getChild(1).getAttribute('value')).toBe(6);
+    });
     it('can correctly parse a simple fate dice roll', () => {
       const lexer = new MockLexer([
         new Token(TokenType.Number, 0, '10'),
@@ -53,6 +69,21 @@ describe('DiceParser', () => {
       expect(dice.getChildCount()).toBe(2);
       expect(dice.getChild(0).type).toBe(NodeType.Number);
       expect(dice.getChild(0).getAttribute('value')).toBe(10);
+      expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
+      expect(dice.getChild(1).getAttribute('value')).toBe('fate');
+    });
+    it('can correctly parse a simple fate dice roll without roll times', () => {
+      const lexer = new MockLexer([
+          new Token(TokenType.Identifier, 0, 'dF')
+      ]);
+      const parser = new Parser.DiceParser(lexer);
+      const result = new Parser.ParseResult();
+      const dice = parser.parseDiceRoll(result);
+      expect(result.errors.length).toBe(0);
+      expect(dice.type).toBe(NodeType.Dice);
+      expect(dice.getChildCount()).toBe(2);
+      expect(dice.getChild(0).type).toBe(NodeType.Number);
+      expect(dice.getChild(0).getAttribute('value')).toBe(1);
       expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
       expect(dice.getChild(1).getAttribute('value')).toBe('fate');
     });
@@ -99,17 +130,6 @@ describe('DiceParser', () => {
       expect(dice.getChild(0).getChild(1).getAttribute('value')).toBe(3);
       expect(dice.getChild(1).type).toBe(NodeType.DiceSides);
       expect(dice.getChild(1).getAttribute('value')).toBe(6);
-    });
-    it('throws on missing roll times', () => {
-      const lexer = new MockLexer([
-        new Token(TokenType.Identifier, 0, 'd'),
-        new Token(TokenType.Number, 1, '10')
-      ]);
-      const parser = new Parser.DiceParser(lexer);
-
-      const result = new Parser.ParseResult();
-      const dice = parser.parseDiceRoll(result);
-      expect(result.errors.length).toBeGreaterThanOrEqual(1);
     });
     it('throws on missing dice value', () => {
       const lexer = new MockLexer([

--- a/src/parser/dice-parser.class.ts
+++ b/src/parser/dice-parser.class.ts
@@ -96,7 +96,11 @@ export class DiceParser extends BasicParser {
     const token = this.lexer.peekNextToken();
     switch (token.type) {
       case TokenType.Identifier:
-        root = this.parseFunction(result);
+        if (token.value === 'd' || token.value === 'dF') {
+          root = this.parseDice(result);
+        } else {
+          root = this.parseFunction(result);
+        }
         break;
       case TokenType.ParenthesisOpen:
         root = this.parseBracketedExpression(result);
@@ -125,6 +129,7 @@ export class DiceParser extends BasicParser {
     switch (token.type) {
       case TokenType.Number: return this.parseNumber(result);
       case TokenType.ParenthesisOpen: return this.parseBracketedExpression(result);
+      case TokenType.Identifier: return Ast.Factory.create(Ast.NodeType.Number).setAttribute('value', Number(1));
       default: this.errorToken(result, TokenType.Number, token);
     }
   }


### PR DESCRIPTION
Allow dice rolls without specifying the number of dices to roll (assumes 1). Also works for fate dices.

This was done be checking if an indentifier is `d` or `dF`. If it is, call `parseDice` without specifying a `rollTimes`. This will force the use of the default `rollTimes` (1).

Updated tests to reflect changes.

Don't know if this was the best approach to do this. Suggestions are welcome.
