### PR TITLE
Added the ability to set a limit for rolls and dice faces

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ const result = dice.roll("1d20").total;
 console.log(result); // Outputs 4.
 ```
 
+#### Limiting the number of rolls or sides
+
+Limit the number of rolls or dice sides by providing a configuration object to the `Dice` constructor:
+
+```typescript
+const dice = new Dice(null, null, {
+    maxRollTimes: 20, // limit to 20 rolls 
+    maxDiceSides: 100, // limit to 100 dice faces
+});
+const result1 = dice.roll("50d10");
+console.log(result1.errors); // Outputs ["Invalid number of rolls: 50. Maximum allowed: 20."]
+const result2 = dice.roll("10d500");
+console.log(result2.errors); // Outputs ["Invalid number of dice sides: 500. Maximum allowed: 500."]
+```
+
 #### Dice Expression Syntax
 
 The dice rolling syntax is based on the system used by Roll20, a detailed explanation of which can be found on the [Roll20 Wiki](https://wiki.roll20.net/Dice_Reference#Roll20_Dice_Specification).

--- a/spec/interpreter/dice-interpreter.evaluate.dice.spec.ts
+++ b/spec/interpreter/dice-interpreter.evaluate.dice.spec.ts
@@ -191,5 +191,25 @@ describe('DiceInterpreter', () => {
       interpreter.evaluate(dice, errors);
       expect(errors.length).toBeGreaterThanOrEqual(1);
     });
+    it('throws on invalid number of rolls (if specified a limit of 3 rolls and rolls 5d6).', () => {
+      const dice = Ast.Factory.create(Ast.NodeType.Dice);
+      dice.addChild(Ast.Factory.create(Ast.NodeType.Number).setAttribute('value', 5));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceSides).setAttribute('value', 6));
+
+      const interpreter = new Interpreter.DiceInterpreter(null, new MockRandomProvider(4), null, {maxRollTimes: 3});
+      const errors: Interpreter.InterpreterError[] = [];
+      interpreter.evaluate(dice, errors);
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+    });
+    it('throws on invalid number of dice sides (if specified a limit of 6 sides and rolls 2d10).', () => {
+      const dice = Ast.Factory.create(Ast.NodeType.Dice);
+      dice.addChild(Ast.Factory.create(Ast.NodeType.Number).setAttribute('value', 2));
+      dice.addChild(Ast.Factory.create(Ast.NodeType.DiceSides).setAttribute('value', 10));
+
+      const interpreter = new Interpreter.DiceInterpreter(null, new MockRandomProvider(4), null, {maxDiceSides: 6});
+      const errors: Interpreter.InterpreterError[] = [];
+      interpreter.evaluate(dice, errors);
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+    });
   });
 });

--- a/src/dice.class.ts
+++ b/src/dice.class.ts
@@ -7,11 +7,13 @@ import { DiceLexer } from './lexer/dice-lexer.class';
 import { Parser } from './parser';
 import { DiceParser } from './parser/dice-parser.class';
 import { RandomProvider } from './random';
+import { InterpreterOptions } from './interpreter/interpreter-options.interface';
 
 export class Dice {
   constructor(
     protected functions?: FunctionDefinitionList,
-    protected randomProvider?: RandomProvider
+    protected randomProvider?: RandomProvider,
+    protected options?: InterpreterOptions,
   ) { }
 
   roll(input: string | CharacterStream): DiceResult {
@@ -31,7 +33,7 @@ export class Dice {
   }
 
   protected createInterpreter(): DiceInterpreter {
-    return new DiceInterpreter(this.functions, this.randomProvider, this.createGenerator());
+    return new DiceInterpreter(this.functions, this.randomProvider, this.createGenerator(), this.options);
   }
 
   protected createGenerator(): DiceGenerator {

--- a/src/interpreter/interpreter-options.interface.ts
+++ b/src/interpreter/interpreter-options.interface.ts
@@ -1,0 +1,4 @@
+export interface InterpreterOptions {
+  maxRollTimes?: number;
+  maxDiceSides?: number;
+}


### PR DESCRIPTION
Fixes #15.

This adds a new configuration to the `Dice` constructor allowing to set the maximum number of roll times and/or dice faces. The check is done in the interpreter.

Example:
```typescript
const dice = new Dice(null, null, {
    maxRollTimes: 20, // limit to 20 rolls 
    maxDiceSides: 100, // limit to 100 dice faces
});
const result1 = dice.roll("50d10");
console.log(result1.errors); // Outputs ["Invalid number of rolls: 50. Maximum allowed: 20."]
const result2 = dice.roll("10d500");
console.log(result2.errors); // Outputs ["Invalid number of dice sides: 500. Maximum allowed: 500."]
```

If this is not the right approach to add this feature, I can update the implementation. I also added new tests and updated the README.md.